### PR TITLE
Add isRunning() function and var on Job

### DIFF
--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -10,6 +10,34 @@ import (
 
 func test() {}
 
+func TestIsRunning(t *testing.T) {
+
+	fn := func() {
+		time.Sleep(35 * time.Millisecond)
+	}
+
+	job, err := Every(1).Seconds().Run(fn)
+	assert.Nil(t, err)
+	assert.NotNil(t, job)
+
+	var i int
+
+FOR:
+	for {
+		time.Sleep(20 * time.Millisecond)
+		i++
+
+		switch i {
+		case 1:
+			assert.Equal(t, true, job.IsRunning())
+
+		case 2:
+			assert.Equal(t, false, job.IsRunning())
+			break FOR
+		}
+	}
+}
+
 func TestExecution(t *testing.T) {
 	c := make(chan bool)
 	fn := func() {


### PR DESCRIPTION
IsRunning will allow external programs to know when a particular job
is running, which may be useful for say graceful shutdown.

Example Situation: Running scheduler from a console application and
when the console application is terminated, say using SIGTERM, it will
quit all of the Jobs using the Quit channel, but also try and wait for
currently running jobs to finish processing before terminating.