### PR TITLE
Schedule by UTC Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/carlescere/scheduler"
+	"github.com/he4d/scheduler"
 )
 
 func main() {

--- a/scheduler.go
+++ b/scheduler.go
@@ -67,7 +67,7 @@ func (d *daily) setTime(h, m, s int) {
 }
 
 func (d daily) nextRun() (time.Duration, error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	year, month, day := now.Date()
 	date := time.Date(year, month, day, d.hour, d.min, d.sec, 0, time.Local)
 	if now.Before(date) {
@@ -83,7 +83,7 @@ type weekly struct {
 }
 
 func (w weekly) nextRun() (time.Duration, error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	year, month, day := now.Date()
 	numDays := w.day - now.Weekday()
 	if numDays == 0 {

--- a/scheduler.go
+++ b/scheduler.go
@@ -69,11 +69,11 @@ func (d *daily) setTime(h, m, s int) {
 func (d daily) nextRun() (time.Duration, error) {
 	now := time.Now().UTC()
 	year, month, day := now.Date()
-	date := time.Date(year, month, day, d.hour, d.min, d.sec, 0, time.Local)
+	date := time.Date(year, month, day, d.hour, d.min, d.sec, 0, time.UTC)
 	if now.Before(date) {
 		return date.Sub(now), nil
 	}
-	date = time.Date(year, month, day+1, d.hour, d.min, d.sec, 0, time.Local)
+	date = time.Date(year, month, day+1, d.hour, d.min, d.sec, 0, time.UTC)
 	return date.Sub(now), nil
 }
 
@@ -91,7 +91,7 @@ func (w weekly) nextRun() (time.Duration, error) {
 	} else if numDays < 0 {
 		numDays += 7
 	}
-	date := time.Date(year, month, day+int(numDays), w.d.hour, w.d.min, w.d.sec, 0, time.Local)
+	date := time.Date(year, month, day+int(numDays), w.d.hour, w.d.min, w.d.sec, 0, time.UTC)
 	return date.Sub(now), nil
 }
 


### PR DESCRIPTION
Daily and weekly scheduling should be done by UTC time. A long running process which uses the scheduler would fail to execute at the correct time when a time change occurred.