### PR TITLE
Add support for a .Delay(x) for recurrent jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ func main() {
 	}
       // Run every 2 seconds but not now.
 	scheduler.Every(2).Seconds().NotImmediately().Run(job)
-      
+
       // Run now and every X.
 	scheduler.Every(5).Minutes().Run(job)
 	scheduler.Every().Day().Run(job)
 	scheduler.Every().Monday().At("08:30").Run(job)
-      
+
       // Keep the program from not exiting.
 	runtime.Goexit()
 }
@@ -52,6 +52,14 @@ By default the behaviour of the recurrent jobs (Every(N) seconds, minutes, hours
 
 ```go
 scheduler.Every(5).Minutes().NotImmediately().Run(job)
+```
+
+## Delayed recurrent jobs
+
+Similar to `NotImmediately()` but allows to define a custom time to delay the first execution
+
+```go
+scheduler.Every(5).Minutes().Delay(10 * time.Second).Run(job)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ func main() {
       // Run every 2 seconds but not now.
 	scheduler.Every(2).Seconds().NotImmediately().Run(job)
 
+      // Run every 1 hour but start in 5 minutes.
+	scheduler.Every(5).Hours().Delay(5).Minutes().Run(job)
+
       // Run now and every X.
 	scheduler.Every(5).Minutes().Run(job)
 	scheduler.Every().Day().Run(job)
@@ -56,10 +59,10 @@ scheduler.Every(5).Minutes().NotImmediately().Run(job)
 
 ## Delayed recurrent jobs
 
-Similar to `NotImmediately()` but allows to define a custom time to delay the first execution
+Similar to `NotImmediately()` but allows to define a custom time to delay the first execution. You must define the
 
 ```go
-scheduler.Every(5).Minutes().Delay(10 * time.Second).Run(job)
+scheduler.Every(5).Minutes().Delay(10).Seconds().Run(job)
 ```
 
 ## License

--- a/scheduler.go
+++ b/scheduler.go
@@ -38,19 +38,23 @@ type Job struct {
 }
 
 type recurrent struct {
-	units        int
-	period       time.Duration
-	initialDelay time.Duration
-	done         bool
+	units       int
+	period      time.Duration
+	delayUnits  int
+	delayPeriod time.Duration
+	done        bool
 }
 
 func (r *recurrent) nextRun() (time.Duration, error) {
 	if r.units == 0 || r.period == 0 {
 		return 0, errors.New("cannot set recurrent time with 0")
 	}
+	if r.delayUnits != 0 && r.delayPeriod == 0 {
+		return 0, errors.New("must set delay time unit")
+	}
 	if !r.done {
 		r.done = true
-		return r.initialDelay, nil
+		return time.Duration(r.delayUnits) * r.delayPeriod, nil
 	}
 	return time.Duration(r.units) * r.period, nil
 }
@@ -127,16 +131,16 @@ func (j *Job) NotImmediately() *Job {
 	return j
 }
 
-// Delayed allows add a custom delay to start the job instead of execute it
+// Delay allows add a custom delay to start the job instead of execute it
 // immediatelly after definition. This is incompatible with NotImmediately()
 // in which case it will start in the next scheduled time regardless the Delay
-func (j *Job) Delay(delay time.Duration) *Job {
+func (j *Job) Delay(delayUnits int) *Job {
 	rj, ok := j.schedule.(*recurrent)
 	if !ok {
 		j.err = errors.New("bad function chaining")
 		return j
 	}
-	rj.initialDelay = delay
+	rj.delayUnits = delayUnits
 	return j
 }
 
@@ -311,7 +315,11 @@ func (j *Job) timeOfDay(d time.Duration) *Job {
 		return j
 	}
 	r := j.schedule.(*recurrent)
-	r.period = d
+	if r.delayUnits == 0 {
+		r.period = d
+	} else {
+		r.delayPeriod = d
+	}
 	j.schedule = r
 	return j
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -330,7 +330,7 @@ func TestEveryHoursNotImmediately(t *testing.T) {
 }
 
 func TestDelay(t *testing.T) {
-	job := Every(1).Hours().Delay(10 * time.Second)
+	job := Every(1).Hours().Delay(10).Seconds()
 
 	actual, err := job.schedule.nextRun()
 	assert.Nil(t, err)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -329,6 +329,17 @@ func TestEveryHoursNotImmediately(t *testing.T) {
 	testEveryX(t, job, expected, false)
 }
 
+func TestDelay(t *testing.T) {
+	job := Every(1).Hours().Delay(10 * time.Second)
+
+	actual, err := job.schedule.nextRun()
+	assert.Nil(t, err)
+	assert.Equal(t, 10*time.Second, actual)
+	actual, err = job.schedule.nextRun()
+	assert.Nil(t, err)
+	assert.Equal(t, 1*time.Hour, actual)
+}
+
 func TestBadRecurrent(t *testing.T) {
 	var units int
 	units = 0

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -238,6 +238,18 @@ func TestBadChain5(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestBadChain6(t *testing.T) {
+	job, err := Every().Monday().Delay(1).Seconds().Run(test)
+	assert.Nil(t, job)
+	assert.NotNil(t, err)
+}
+
+func TestBadChain7(t *testing.T) {
+	job, err := Every(1).Minutes().Delay(1).Run(test)
+	assert.Nil(t, job)
+	assert.NotNil(t, err)
+}
+
 func TestBadEvery(t *testing.T) {
 	job, err := Every(1, 2).Seconds().Run(test)
 	assert.Nil(t, job)


### PR DESCRIPTION
In ocassions we want to add some delay to a recurrent job that is different to the recurrent period itself.

I add a `.Delay()` modifier that changes the time for the initial delay. This
in incompatible to `NotImmediatelly()`.

I added here two possible implementation in two different commits:

 - `.Delay(10 * time.Second)`: we pass a `time.Duration` directly
 - `.Delay(10).Seconds()`: more complex and magic behaviour, it behaves
   like `Every(x)`, but nicer to read

Let me know which one you like the most and I can rebase this PR (or just merge it if you like it :))